### PR TITLE
docs: improve procedure for cloning from SD to SSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Follow the procedure in the `docs/` directory:
 
 * [Update Raspberry Firmware #1](https://lemariva.com/blog/2020/12/raspberry-pi-4-ssd-booting-enabled-trim)
 * [Raspberry Firmware Release Notes](https://github.com/raspberrypi/rpi-eeprom)
+* [Boot from USB](https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#usb-mass-storage-boot)
 * [Debian for RPi](https://raspi.debian.net/defaults-and-settings/)
 * [Image clone guide](https://notenoughtech.com/raspberry-pi/how-to-boot-raspberry-pi-4-from-usb/)
 * [RPi Clone tool](https://github.com/billw2/rpi-clone)

--- a/docs/03-clone-image-on-ssd.md
+++ b/docs/03-clone-image-on-ssd.md
@@ -1,5 +1,13 @@
 # Clone SD image on SSD disk and mount it as root
 
+NOTE: after a long research, and many trial and error attempts, I could not make the system to boot
+entirely from SSD, but only mounting the `root` partition. Thus, at the moment, the following guide
+allows you to boot from SD and mount `root` from SSD right after boot.
+It could be possible to make it work by using the `vcgencmd` command to set the `BOOT_ORDER=0xf41`
+parameter as explained in [the official Raspberry Pi guide](https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#usb-mass-storage-boot).
+At the time of writing this, Debian for raspberry does not have the `vcgencmd` in its repository,
+and I had not yet time to workaround on this.
+
 0. Hardware setup
 
 We assume that all Raspberry Pis are up, and running the new Debian image from the SD.
@@ -70,7 +78,44 @@ EOS
 apt update
 ```
 
-8. Run the `rpi-clone` script:
+8. Preparing SSD
+
+There are many ways we can use the SSD to expose the storage as the persistent volume. My recommendation is to reserve the
+remaining disk space to that, leaving the first two partitions to host the `boot` and `root` from the SD.
+
+Before cloning the data with the `rpi-clone` script, the SSD should present the same partition table. To copy the partition table
+we will use `sfdisk` to dump it as follows:
+
+``` bash
+sfdisk -d /dev/mmcblk1 > partition_table_sd
+```
+
+Then we write the table to the SSD:
+
+``` bash
+sfdisk /dev/sda < partition_table_sd
+```
+
+This allows `rpi-clone` script to automatically perform the right actions for cloning the SD data to the SDD (see point 7 of the
+[README](https://github.com/billw2/rpi-clone?tab=readme-ov-file#7-clone-sd-card-to-usb-disk-with-extra-partitions)).
+
+Now we can manipulate the second partition to add more space, e.g. increasing it with `cfdisk`.
+
+``` bash
+cfdisk /dev/sda
+```
+
+for example to resize the 16GB for the `root` partition to something bigger: e.g. 64GB.
+
+Then recreate the filsystem with the right label:
+
+``` bash
+mkfs.ext4 /dev/sda2 -L ROOT
+```
+
+9. Cloning SD to SSD
+
+Run the `rpi-clone` script:
 
 ``` bash
 ./rpi-clone-master/rpi-clone /dev/sda
@@ -80,8 +125,9 @@ Output (if `rsync` is not installed):
 
 ``` bash
 Command not found: rsync       Package required: rsync
+Command not found: column      Package required: bsdmainutils
 
-Do you want to apt-get install the packages?  (yes/no):
+Do you want to apt-get install the packages?  (yes/no): yes
 ```
 
 Then:
@@ -89,49 +135,40 @@ Then:
 ``` bash
 Booted disk: mmcblk1 15.9GB                Destination disk: sda 1.0TB
 ---------------------------------------------------------------------------
-Part               Size    FS     Label           Part   Size  FS  Label  
-1 /boot/firmware   299.0M  fat16  --                                      
-2 root              14.5G  ext4   RASPIROOT                               
+Part               Size    FS     Label           Part   Size    FS     Label
+1 /boot/firmware   508.0M  fat16  --              1      508.0M  fat16  --
+2 root              14.3G  ext4   RASPIROOT       2       64.0G  ext4   ROOT
 ---------------------------------------------------------------------------
-== Initialize: IMAGE partition table - partition number mismatch: 2 -> 0 ==
-1 /boot/firmware      (72.5M used)   : MKFS  SYNC to sda1
-2 root                (782.0M used)  : RESIZE  MKFS  SYNC to sda2
+== SYNC mmcblk1 file systems to sda ==
+/boot/firmware        (82.0M used)   : SYNC to sda1 (508.0M size)
+/                     (928.0M used)  : SYNC to sda2 (64.0G size)
 ---------------------------------------------------------------------------
 Run setup script       : no.
 Verbose mode           : no.
 -----------------------:
-** WARNING **          : All destination disk sda data will be overwritten!
------------------------:
 
-Initialize and clone to the destination disk sda?  (yes/no): yes
+Ok to proceed with the clone?  (yes/no): yes
 ```
 
-Insert `ROOT` when asked for file system label:
+Enter `yes` to proceed:
 
 ``` bash
-Optional destination ext type file system label (16 chars max): ROOT
-
-Initializing
-  Imaging past partition 1 start.
-  => dd if=/dev/mmcblk1 of=/dev/sda bs=1M count=5 ...
-  Resizing destination disk last partition ...
-    Resize success.
-  Changing destination Disk ID ...
-  => mkfs -t vfat  /dev/sda1 ...
-  => mkfs -t ext4  /dev/sda2 ...
-
 Syncing file systems (can take a long time)
 Syncing mounted partitions:
   Mounting /dev/sda2 on /mnt/clone
+mount: (hint) your fstab has been modified, but systemd still uses
+       the old version; use 'systemctl daemon-reload' to reload.
   => rsync // /mnt/clone with-root-excludes ...
   Mounting /dev/sda1 on /mnt/clone/boot/firmware
+mount: (hint) your fstab has been modified, but systemd still uses
+       the old version; use 'systemctl daemon-reload' to reload.
   => rsync /boot/firmware/ /mnt/clone/boot/firmware  ...
 
 ===============================
 Done with clone to /dev/sda
-   Start - 21:07:04    End - 21:07:48    Elapsed Time - 0:44
+   Start - 22:36:18    End - 22:36:29    Elapsed Time - 0:11
 
-Cloned partitions are mounted on /mnt/clone for inspection or customizing. 
+Cloned partitions are mounted on /mnt/clone for inspection or customizing.
 
 Hit Enter when ready to unmount the /dev/sda partitions ...
   unmounting /mnt/clone/boot/firmware
@@ -139,13 +176,13 @@ Hit Enter when ready to unmount the /dev/sda partitions ...
 ===============================
 ```
 
-9. Reboot the RPi system to check whether the changes will be successfully applied:
+10. Reboot the RPi system to check whether the changes will be successfully applied:
 
 ``` bash
 systemctl reboot
 ```
 
-10. Reconnect and verify:
+11. Reconnect and verify:
 
 ``` bash
 lsblk
@@ -162,9 +199,4 @@ mmcblk1     179:0    0  14.9G  0 disk
 |-mmcblk1p1 179:1    0   299M  0 part /boot/firmware
 `-mmcblk1p2 179:2    0  14.6G  0 part
 ```
-
-WARNING: since we changed the label to `ROOT`, everytime we upgrade Debian, that label
-will be changed back to `RASPIROOT` in the `cmdline.txt` file, preventing the node to
-properly reboot using the correct partition. In case the node won't come up after an upgrade,
-turn it off, mount the SD card on another computer and change it back to `root=LABEL=ROOT`.
 


### PR DESCRIPTION
This patch clarifies a bit better the reason for some decisions made in the procedure to clone SD to SSD.
Moreover allows to use a dedicated partition of the SSD as storage for the persistent volume, instead of using the same `root` partition.