### PR TITLE
docs: improve docs readability and fix typos

### DIFF
--- a/docs/02-install-debian.md
+++ b/docs/02-install-debian.md
@@ -14,7 +14,7 @@ unxz 20210210_raspi_4_buster.img.xz
 
 ## TL;DR
 
-There's a very basic script that perform all the steps required in this chapter,
+There's a very basic script that performs all the steps required in this chapter,
 moreover it does install `rpi-clone` repository into the `root` home of the SD card,
 for later use.
 
@@ -28,7 +28,7 @@ For example:
 ./scripts/install-sd.sh -i distro-images/20210210_raspi_4_buster.img -d /dev/sdd -k ~/.ssh/kluster.pub -h "kluster-pi-01"
 ```
 
-Or you can manually perform the follwoing procedure.
+Or you can manually perform the following procedure.
 
 ## Write Image
 

--- a/docs/03-clone-image-on-ssd.md
+++ b/docs/03-clone-image-on-ssd.md
@@ -80,8 +80,8 @@ apt update
 
 8. Preparing SSD
 
-There are many ways we can use the SSD to expose the storage as the persistent volume. My recommendation is to reserve the
-remaining disk space to that, leaving the first two partitions to host the `boot` and `root` from the SD.
+There are many ways we can use the SSD to expose the storage as persistent volume in Kubernetes. My recommendation at this stage
+is to dedicate the first two partitions to `boot` and `root` respectively, and to use the remaining disk space as Kubernetes storage.
 
 Before cloning the data with the `rpi-clone` script, the SSD should present the same partition table. To copy the partition table
 we will use `sfdisk` to dump it as follows:
@@ -99,13 +99,11 @@ sfdisk /dev/sda < partition_table_sd
 This allows `rpi-clone` script to automatically perform the right actions for cloning the SD data to the SDD (see point 7 of the
 [README](https://github.com/billw2/rpi-clone?tab=readme-ov-file#7-clone-sd-card-to-usb-disk-with-extra-partitions)).
 
-Now we can manipulate the second partition to add more space, e.g. increasing it with `cfdisk`.
+First, let's increase the size of the `root` partition on the SSD, using `cfdisk`, e.g. increase it to 32 or 64 GB:
 
 ``` bash
 cfdisk /dev/sda
 ```
-
-for example to resize the 16GB for the `root` partition to something bigger: e.g. 64GB.
 
 Then recreate the filsystem with the right label:
 
@@ -121,7 +119,7 @@ Run the `rpi-clone` script:
 ./rpi-clone-master/rpi-clone /dev/sda
 ```
 
-Output (if `rsync` is not installed):
+Output if some packages are missing:
 
 ``` bash
 Command not found: rsync       Package required: rsync
@@ -129,6 +127,8 @@ Command not found: column      Package required: bsdmainutils
 
 Do you want to apt-get install the packages?  (yes/no): yes
 ```
+
+Answer `yes` and proceed.
 
 Then:
 
@@ -191,12 +191,11 @@ lsblk
 Output:
 
 ``` bash
-NAME        MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
+NAME        MAJ:MIN RM   SIZE RO TYPE MOUNTPOINTS
 sda           8:0    0 931.5G  0 disk
-|-sda1        8:1    0   299M  0 part
-`-sda2        8:2    0 931.2G  0 part /
-mmcblk1     179:0    0  14.9G  0 disk
-|-mmcblk1p1 179:1    0   299M  0 part /boot/firmware
-`-mmcblk1p2 179:2    0  14.6G  0 part
+|-sda1        8:1    0   508M  0 part
+`-sda2        8:2    0    64G  0 part /
+mmcblk1     179:0    0  14.8G  0 disk
+|-mmcblk1p1 179:1    0   508M  0 part /boot/firmware
+`-mmcblk1p2 179:2    0  14.3G  0 part
 ```
-

--- a/docs/04-preparing-nodes.md
+++ b/docs/04-preparing-nodes.md
@@ -2,21 +2,32 @@
 
 In order to host k3s on each node we must follow [its requirements](https://docs.k3s.io/installation/requirements).
 
-## Enabling legacy iptables
+## Install iptables
 
 ``` bash
-sudo iptables -F
-sudo update-alternatives --set iptables /usr/sbin/iptables-legacy
-sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
-sudo reboot
+apt install iptables
+```
+
+### Enable iptables legacy (only for iptables < v1.6.1)
+
+[Read this first](https://docs.k3s.io/known-issues#iptables).
+
+The following actions are not needed on Debian Bookworm (iptables >= 1.8.9):
+
+``` bash
+iptables -F
+update-alternatives --set iptables /usr/sbin/iptables-legacy
+update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+reboot
 ```
 
 ## Enabling cgroups
+
+This has already been done in the previous chapter of the procedure.
 
 Example of `/boot/firmware/cmdline.txt`
 
 ``` bash
 console=serial0,115200 console=tty1 root=LABEL=ROOT rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait cgroup_memory=1 cgroup_enable=memory cgroup_enable=cpuset
 ```
-
 

--- a/docs/05-setup-k8s.md
+++ b/docs/05-setup-k8s.md
@@ -14,18 +14,22 @@ and replaced by their alternatives when required:
 ## TL;DR
 
 One of the purpose of this prject is to learn by doing. This is why I documented each step
-instead of sharing a single bash script or an ansible playbook.
-But, I also provide scripts to automate some of the steps for the entire procedure in order to
-make it repeatable and fast to deploy for experimenting.
+instead of just sharing a single bash script or an ansible playbook.
+But, I also provide scripts to automate some of the steps for the entire procedure to make
+it repeatable and fast to deploy for experimenting.
 
 ### Select versions
 
-The `resources.list` file contains the version for each desired component when installed with the
-`scripts/deploy-resources.sh` script. Alternatevely, you can use each resource's `install.sh`
-script inside each of them subdirectory: e.g. `resources/calico/install.sh`.
+There are two ways to install resources.
+The first one is using the resource's `install.sh` script (e.g. `resources/calico/install.sh`)
+which has the component's version hard-code inside.
 
-Versions are hardcoded in each resource's `install.sh` file, but are overridden by the
-`resources.list` file when `scripts/deploy-resources.sh resources.list` is executed.
+The second approach is to use the `scripts/deploy-resources.sh` which requests a `resources.list`
+file as argument. The `resources.list` file contains the version for each desired component.
+
+The `scripts/deploy-resources.sh` is basically a wrapper which calls each resource's `install.sh`
+script. Versions in each resource's `install.sh` file will be overridden by the `resources.list`
+file when `scripts/deploy-resources.sh resources.list` is executed.
 
 ### Installing K3S
 
@@ -44,7 +48,7 @@ Usage:
 bash scripts/install-kluster.sh -h hosts.list -r resources.list
 ```
 
-The script will write the TOKEN generated automatically in the hiddent file `.k3s-token` inside the
+The script will write the TOKEN, automatically generated, in the hidden `.k3s-token` file inside the
 root of the project.
 
 Or you can manually perform the following procedure.


### PR DESCRIPTION
As a late self review, this patch brings improvements across almost all the chapters in the `/docs` directory.
Mainly rephrasing hard-to-follow sentences and shortening long ones.
Also fix some typos, which is always good.