### PR TITLE
fix-1: minor fix for cleanup func in install sd script

### DIFF
--- a/scripts/install-sd.sh
+++ b/scripts/install-sd.sh
@@ -172,7 +172,7 @@ clean_up() {
     echo ""
     echo "Unmounting partitions..."
     
-    sudo sync
+    sync
 
     if findmnt "${BOOT}" > /dev/null
     then
@@ -187,8 +187,15 @@ clean_up() {
     echo ""
     echo "Removing temp dirs..."
     
-    rmdir "${BOOT}"
-    rmdir "${ROOT}"
+    if [[ -d "${BOOT}" ]]
+    then
+        rmdir "${BOOT}"
+    fi
+    if [[ -d "${ROOT}" ]]
+    then
+        rmdir "${ROOT}"
+    fi
+
     rmdir "${TEMPDIR}"
 }
 
@@ -285,4 +292,3 @@ main() {
 }
 
 main "${@}"
-


### PR DESCRIPTION
This patch prevents errors when the script fails, and the cleanup function is triggered by the ERR signal,
by checking the existence of temporary directories before attempt to remove them.
Also it stop asking for `sudo` password for `sync` when the script fails.