### PR TITLE
feat: add fstrim setup script and procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Follow the procedure in the `docs/` directory:
 * [RPi Clone tool](https://github.com/billw2/rpi-clone)
 * [RPi Boot from SSD](https://jamesachambers.com/new-raspberry-pi-4-bootloader-usb-network-boot-guide/)
 * [Raspberry Pi cheat sheet](https://github.com/LukaszLapaj/raspberry-pi-cheat-sheet)
+* [SSD TRIM](https://www.techtarget.com/searchstorage/definition/TRIM)
 
 ### Kubernetes
 

--- a/docs/03-clone-image-on-ssd.md
+++ b/docs/03-clone-image-on-ssd.md
@@ -61,7 +61,7 @@ in this case `/dev/sda` is the target disk.
 Since we are touching the `cmdline.txt` file, we should as well set the `cgroups` required for running containers:
 
 ``` bash
-console=tty0 console=ttyS1,115200 root=LABEL=ROOT rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait cgroup_memory=1 cgroup_enable=memory cgroup_enable=cpuset
+console=tty0 console=ttyS1,115200 root=LABEL=ROOT rootfstype=ext4 fsck.repair=yes rootwait elevator=deadline cgroup_memory=1 cgroup_enable=memory cgroup_enable=cpuset
 ```
 
 Let's add the extra file to persist the changes:

--- a/docs/04-preparing-nodes.md
+++ b/docs/04-preparing-nodes.md
@@ -1,6 +1,7 @@
-# Nodes Preparation 
+# Nodes Preparation
 
-In order to host k3s on each node we must follow [its requirements](https://docs.k3s.io/installation/requirements).
+In order to host k3s on each node we must ensure [its requirements](https://docs.k3s.io/installation/requirements?os=pi)
+are respected for the Raspberry Pi use case.
 
 ## Install iptables
 
@@ -21,13 +22,35 @@ update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 reboot
 ```
 
-## Enabling cgroups
+## Ensure cgroups
 
 This has already been done in the previous chapter of the procedure.
 
 Example of `/boot/firmware/cmdline.txt`
 
 ``` bash
-console=serial0,115200 console=tty1 root=LABEL=ROOT rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait cgroup_memory=1 cgroup_enable=memory cgroup_enable=cpuset
+console=serial0,115200 console=tty1 root=LABEL=ROOT rootfstype=ext4 fsck.repair=yes rootwait elevator=deadline cgroup_memory=1 cgroup_enable=memory cgroup_enable=cpuset
 ```
+
+## SSD TRIM
+
+Since we are using SSDs as main storage, we would like to keep their performances for long time. The SSD TRIM process
+ensures good performance of the SSD by erasing data blocks that are not in use anymore. In this way any new writes will
+not wait for the blocks to be erased first.
+
+NOTE: not every SATA to USB3.0 adapter supports TRIM. That's why, after a long reserch, I chose the "UGREEN USB 3.0 to SATA Adapter"
+which supports both UASP and TRIM.
+
+Here you can follow one of the procedures to enable SSD TRIM in Debian:
+
+* https://lemariva.com/blog/2020/12/raspberry-pi-4-ssd-booting-enabled-trim
+* https://www.jeffgeerling.com/blog/2020/enabling-trim-on-external-ssd-on-raspberry-pi
+
+Or use the script that takes care of every steps:
+
+``` bash
+bash scripts/enable-fstrim.sh -h hosts.list
+```
+
+IMPORTANT: the above script sends remote commands to the nodes, so must run from the local host that has SSH access to the nodes.
 

--- a/scripts/enable-fstrim.sh
+++ b/scripts/enable-fstrim.sh
@@ -1,0 +1,153 @@
+#!/bin/env bash
+
+##
+## Copyright Jonathan Battiato
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+set -eEuo pipefail
+set -m
+
+if [[ "${TRACE:-0}" == "1" ]]; then
+    set -x
+fi
+
+usage(){
+    echo "Usage: $0 -h [<hosts-list-file>|<remote_address>]" >&2
+    echo "" >&2
+    exit 1
+}
+
+read_hosts_list(){
+    local node
+    local node_address
+
+    ## Read the HOSTS file and get the nodes IP address
+    while IFS='=' read -r node node_address
+    do
+        if [[ -z "${node_address}" ]]
+        then
+            echo "ERROR: missing node address: ${node}" >&2
+            echo "" >&2
+            exit 1
+        else
+            NODE_ADDRESSES+=( "${node_address}" )
+            eval "${node}"="${node_address}"
+        fi
+    done < <(grep "^.*_" "${HOSTS}" | tr -d '"')
+}
+
+group_setup(){
+    local node
+    for node in ${NODE_ADDRESSES[@]}
+    do
+        setup_fstrim "${node}"
+    done
+}
+
+setup_fstrim(){
+    local node
+    node="${1}"
+
+    # Remote install required packages
+    ssh root@"${node}" "apt install -y usbutils bc sg3-utils lsscsi"
+
+    ssh -Tq root@"${node}" <<'EOS'
+    # Retrieve values and set variables
+    UNMAP_COUNT=$(sg_vpd -p bl /dev/sda | awk -F':' '{if ($1 ~ "Maximum unmap LBA count") {print $2}}')
+    UNMAP_SUPPORT=$(sg_vpd -p lbpv /dev/sda | awk -F':' '{if ($1 ~ "Unmap command supported") {print $2}}')
+    LOGICAL_BLOCK=$(sg_readcap -l /dev/sda | awk -F'=' '{if ($1 ~ "Logical block length") {print $2 | "cut -d \" \" -f1"}}')
+
+    # Activate fstrim only if supported
+    if [[ $UNMAP_SUPPORT -eq "1" ]]; then
+        MAX_BYTE=$(echo  "$UNMAP_COUNT * $LOGICAL_BLOCK" | bc)
+        USB_ID=$(lsusb | awk -F' ' '{if ($0 ~ "SATA") {print $6}}')
+        VENDOR_ID=${USB_ID:0:4}
+        PRODUCT_ID=${USB_ID:5}
+
+        DEVICE=$(find /sys/ -name provisioning_mode)
+
+        # Activate fstrim
+        echo unmap > ${DEVICE}
+        echo $MAX_BYTE > /sys/block/sda/queue/discard_max_bytes
+
+        # Persist conf
+        cat <<EOF >/etc/udev/rules.d/10-trim.rules
+ACTION=="add|change", ATTRS{idVendor}=="$VENDOR_ID", ATTRS{idProduct}=="$PRODUCT_ID", SUBSYSTEM=="scsi_disk", ATTR{provisioning_mode}="unmap"
+KERNEL=="sda", SUBSYSTEM=="block", ATTR{queue/discard_max_bytes}="$MAX_BYTE"
+ACTION=="add|change", ATTRS{idVendor}=="$VENDOR_ID", ATTRS{idProduct}=="$PRODUCT_ID", SUBSYSTEM=="block", ATTR{queue/discard_max_bytes}="$MAX_BYTE"
+EOF
+
+    fi
+EOS
+}
+
+main(){
+    SCRIPT_DIR=$(realpath "$(dirname "$0")")
+    ROOT_DIR=${SCRIPT_DIR}/../
+    unset NODE_ADDRESSES
+    declare -a NODE_ADDRESSES
+
+    if [[ $# -eq 0 ]]
+    then
+        echo "ERROR: no argument passed." >&2
+        echo "" >&2
+        usage
+    fi
+
+    if ! getopt -T > /dev/null; then
+        # GNU enhanced getopt is available
+        parsed_opts=$(getopt -o h:r: -l "hosts:remote:" -- "$@") || usage
+    else
+        # Original getopt is available
+        parsed_opts=$(getopt h:r: "$@") || usage
+    fi
+
+    eval "set -- $parsed_opts"
+
+    for o
+    do
+        case "${o}" in
+            -h | --hosts)
+                shift
+                HOSTS="${1}"
+                shift
+                ;;
+            --)
+                shift
+                break
+                ;;
+        esac
+    done
+
+    if [[ -z "${HOSTS:-}" ]]
+    then
+        echo "ERROR: missing parameter: -h" >&2
+        echo "" >&2
+        usage
+    fi
+
+    if [[ -f "${HOSTS}" ]]
+    then
+        # it's a file
+        read_hosts_list
+        group_setup
+    else
+        # it's an address
+        setup_fstrim ${HOSTS}
+    fi
+}
+
+main "${@}"
+


### PR DESCRIPTION
This patch adds a script that enables SSD TRIM in kluster-pi nodes.
In the documentation there's a brief explanation of what SSD TRIM and why is important to have it enabled.
One could follow one of the links in the documentation to enable SSD TRIM manually and find resources which go deeper in the topic.