### PR TITLE
fix: add install curl to satisfy dependency

### DIFF
--- a/scripts/init-k3s-master.sh
+++ b/scripts/init-k3s-master.sh
@@ -22,6 +22,8 @@ then
     exit 1
 fi
 
+apt install -y curl
+
 K3S_KUBECONFIG_OUTPUT=/root/k3s-kube.config
 
 curl -sfL https://get.k3s.io | \

--- a/scripts/join-k3s-agent.sh
+++ b/scripts/join-k3s-agent.sh
@@ -22,6 +22,8 @@ then
     exit 1
 fi
 
+apt install -y curl
+
 curl -sfL https://get.k3s.io | \
   K3S_TOKEN=${1} \
   K3S_URL=https://${2}:6443 \

--- a/scripts/join-k3s-master.sh
+++ b/scripts/join-k3s-master.sh
@@ -22,6 +22,8 @@ then
     exit 1
 fi
 
+apt install -y curl
+
 curl -sfL https://get.k3s.io | \
   K3S_TOKEN=${1} \
   K3S_KUBECONFIG_OUTPUT=/root/k3s-kube.config \


### PR DESCRIPTION
The missing `curl` command caused k3s scripts to fail.
Adding `apt install -y curl` to the following scripts solved the issue:

- init-k3s-master.sh
- join-k3s-master.sh
- join-k3s-agent.sh
