### PR TITLE
docs: add loadbalancer and ingresses sections

### DIFF
--- a/docs/05-additional-resources.md
+++ b/docs/05-additional-resources.md
@@ -2,6 +2,8 @@
 
 This is a separate section to install resources that are not required to make the cluster work.
 
+* [Ingresses](ingresses.md)
+* [Load Balancers](load-balancers.md)
 * [Container Storage Interfaces](container-storage-interfaces.md)
 * [Certificate Manager](cert-manager.md)
 * [Databases](databases.md)

--- a/docs/ingresses.md
+++ b/docs/ingresses.md
@@ -1,0 +1,13 @@
+# Ingresses
+
+An ingress in kubernetes is required if you want to expose a web server to the network (outside the kubernetes cluster).
+
+## Ingress Nginx
+
+[https://kubernetes.github.io/ingress-nginx/](https://kubernetes.github.io/ingress-nginx/)
+
+Installing the `ingress-nginx` ingress is as easy as applying the manifest of its deployment:
+
+``` bash
+kubectl apply -f "https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.10.1/deploy/static/provider/cloud/deploy.yaml"
+```

--- a/docs/load-balancers.md
+++ b/docs/load-balancers.md
@@ -1,0 +1,60 @@
+# Load Balancers
+
+A load balancer is a type of service that will redirect the traffic from the external network to the configured internal services.
+Unfortunately this kind of service is not implemented directly by Kubernetes, but delegated to the cloud providers.
+
+## MetalLB
+
+[https://metallb.io/](https://metallb.io/)
+
+MetalLB is an implementation of a Kubernetes' load balancer service for baremetal clusters (like in our case).
+
+
+``` bash
+kubectl apply -f "https://raw.githubusercontent.com/metallb/metallb/v0.13.11/config/manifests/metallb-native.yaml"
+```
+
+To announce the IP assigned to the services I chose [the Layer 2 configuration](https://metallb.io/configuration/#layer-2-configuration) for simplicity.
+
+1. Create an address pool resource:
+
+``` bash
+cat > ip-address-pool.yaml <<EOF
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: first-pool
+  namespace: metallb-system
+spec:
+  addresses:
+      # e.g. if your local network is 192.168.1.0/24
+      - 192.168.1.10-192.168.1.19
+EOF
+```
+
+and apply it:
+
+``` bash
+kubectl apply -f ip-address-pool.yaml
+```
+
+2. Create the Level 2 Advertisement resource:
+
+``` bash
+cat > l2-advertisement.yaml <<EOF
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: kluster-pi-l2-adv
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - first-pool
+```
+
+and apply it:
+
+``` bash
+kubectl apply -f l2-advertisement.yaml
+```
+


### PR DESCRIPTION
This patch adds documentation section for both load balancers and ingresses.
In particular this covers MetalLB and Ingress Nginx.