### PR TITLE
feat: add topolvm as optional csi

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ The final product is a K3S cluster with [`etcd` in HA](https://docs.k3s.io/datas
 K3S will use:
 
 * [calico](https://docs.k3s.io/networking/basic-network-options?cni=Calico#custom-cni) as CNI
-* [Metallb](https://metallb.io/) as load balancer
-* [ingress-nginx](https://kubernetes.github.io/ingress-nginx/) as ingress
-* optional [CSIs](docs/container-storage-interfaces.md)
-* optional [cert-manager](https://cert-manager.io/)
+* (optional) [Metallb](https://metallb.io/) as load balancer
+* (optional) [ingress-nginx](https://kubernetes.github.io/ingress-nginx/) as ingress
+* (optional) [CSIs](docs/container-storage-interfaces.md)
+* (optional) [cert-manager](https://cert-manager.io/)
 
 ## Purpose
 
@@ -119,6 +119,7 @@ Follow the procedure in the `docs/` directory:
 ### Storage
 
 * [Longhorn on GH](https://github.com/longhorn/longhorn)
+* [TopoLVM on GH](https://github.com/topolvm/topolvm)
 
 ### Ingress
 

--- a/resources.list
+++ b/resources.list
@@ -3,4 +3,5 @@ ingress-nginx:v1.11.2
 metallb:v0.14.8
 #cert-manager:v1.15.3
 #longhorn:v1.7.1
+#topolvm:v15.4.0
 #cloudnative-pg:1.24.0

--- a/resources/topolvm/install.sh
+++ b/resources/topolvm/install.sh
@@ -1,0 +1,61 @@
+#!/bin/env bash
+
+##
+## Copyright Jonathan Battiato
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+set -eEuo pipefail
+set -m
+
+if [[ "${TRACE:-0}" == "1" ]]; then
+    set -x
+fi
+
+VERSION=${VERSION:-v15.4.0}
+KUBECONFIG="${KUBECONFIG:-${HOME}/.kube/kluster-pi-config}"
+export KUBECONFIG
+
+if ! kubectl get ns >/dev/null 2>&1
+then
+    echo "" >&2
+    echo "ERROR: cannot reach kubernetes cluster." >&2
+    echo " HINT: check the kube config." >&2
+    exit 1
+fi
+
+if ! kubectl get ns cert-manager >/dev/null 2>&1
+then
+    echo "" >&2
+    echo "ERROR: missing dependency: cert-manager." >&2
+    echo "  FIX: install cert-manager firsr." >&2
+    exit 1
+fi
+
+## Create Namespace
+kubectl create ns topolvm-system
+## Label Namespaces
+kubectl label namespace topolvm-system topolvm.io/webhook=ignore
+kubectl label namespace kube-system topolvm.io/webhook=ignore
+
+# Setup Helm
+helm repo add topolvm https://topolvm.github.io/topolvm
+helm repo update topolvm
+
+# Install topoLVM
+helm install --namespace=topolvm-system topolvm topolvm/topolvm --version ${VERSION}
+
+# Check installation
+kubectl get pod -n topolvm-system
+

--- a/resources/topolvm/prepare_node.sh
+++ b/resources/topolvm/prepare_node.sh
@@ -1,0 +1,142 @@
+#!/bin/env bash
+
+##
+## Copyright Jonathan Battiato
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+set -eEuo pipefail
+set -m
+
+if [[ "${TRACE:-0}" == "1" ]]; then
+    set -x
+fi
+
+usage(){
+    echo "Usage: $0 -h [<hosts-list-file>|<remote_address>] -p <remote_partition>" >&2
+    echo "" >&2
+    exit 1
+}
+
+read_hosts_list(){
+    local node
+    local node_address
+
+    ## Read the HOSTS file and get the nodes IP address
+    while IFS='=' read -r node node_address
+    do
+        if [[ -z "${node_address}" ]]
+        then
+            echo "ERROR: missing node address: ${node}" >&2
+            echo "" >&2
+            exit 1
+        else
+            NODE_ADDRESSES+=( "${node_address}" )
+            eval "${node}"="${node_address}"
+        fi
+    done < <(grep "^[MA].*_" "${HOSTS}" | tr -d '"')
+}
+
+group_setup(){
+    local node
+    for node in "${NODE_ADDRESSES[@]}"
+    do
+        setup_node "${node}"
+    done
+}
+
+setup_node(){
+    local node
+    node="${1}"
+
+    # Prepare Node
+    ## Install dependency
+    ssh -Tq root@"${node}" "apt-get -y install lvm2"
+
+    if ! ssh -Tq root@"${node}" "vgdisplay myvg1 >/dev/null 2>&1"
+    then
+        ## Setup LVM partition
+        ssh -Tq root@"${node}" "pvcreate ${PARTITION}"
+        ssh -Tq root@"${node}" "vgcreate myvg1 ${PARTITION}"
+    fi
+}
+
+main(){
+    unset NODE_ADDRESSES
+    declare -a NODE_ADDRESSES
+
+    if [[ $# -eq 0 ]]
+    then
+        echo "ERROR: missing -h arguments." >&2
+        echo "" >&2
+        usage
+    fi
+
+    if ! getopt -T > /dev/null; then
+        # GNU enhanced getopt is available
+        parsed_opts=$(getopt -o h:p: -l "hosts:,partition:" -- "$@") || usage
+    else
+        # Original getopt is available
+        parsed_opts=$(getopt h:p: "$@") || usage
+    fi
+
+    eval "set -- $parsed_opts"
+
+    for o
+    do
+        case "${o}" in
+            -h | --hosts)
+                shift
+                HOSTS="${1}"
+                shift
+                ;;
+            -p | --partition)
+                shift
+                PARTITION="${1}"
+                shift
+                ;;
+            --)
+                shift
+                break
+                ;;
+        esac
+    done
+
+    if [[ -z ${HOSTS:-} ]]
+    then
+        echo "ERROR: missing arg for -h option" >&2
+        echo "" >&2
+        usage
+    fi
+
+    if [[ -z ${PARTITION:-} ]]
+    then
+        echo "ERROR: missing arg for -p option" >&2
+        echo "" >&2
+        usage
+    fi
+
+    if [[ -f "${HOSTS}" ]]
+    then
+        # it's a file
+        read_hosts_list
+        group_setup
+    else
+        # it's an address
+        setup_node "${HOSTS}"
+    fi
+}
+
+main "${@}"
+


### PR DESCRIPTION
This patch introduce the TopoLVM CSI.
TopoLVM installation requires to setup each nodes with LVM and a volume group called `myvg1`.
These prerequisites can be satisfied using the `prepare_node.sh` script.
Then the `resources/topolvm/install.sh` script will install topolvm using Helm.