### PR TITLE
feat: add k3s automatic upgrade controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Follow the procedure in the `docs/` directory:
 3. [Prepare RPi nodes installing and configuring packages](docs/03-preparing-nodes.md)
 4. [Setup cluster installing k3s on each node](docs/04-setup-k8s.md)
 5. [Install additional resources](docs/05-additional-resources.md)
+6. [Day 2 Operations](docs/06-day-2-operations.md)
 
 ## Scripts
 

--- a/docs/06-day-2-operations.md
+++ b/docs/06-day-2-operations.md
@@ -1,0 +1,6 @@
+# Day 2 Operations
+
+* [Maintenance](maintenance.md)
+* [Observability](osbervability.md)
+* [Backups](backups.md)
+

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,0 +1,65 @@
+# Maintenance
+
+## K3S upgrade
+
+[https://docs.k3s.io/upgrades/automated](https://docs.k3s.io/upgrades/automated)
+
+To keep your Kluster Pi up to date, Rancher created a controller to automatically upgrade the K3S cluster, node by node, using the so called [System Upgrade Controller](https://github.com/rancher/system-upgrade-controller/).
+
+To install the controller:
+
+``` bash
+export KUBECONFIG=${HOME}/.kube/kluster-pi-config
+# Y.O.L.O.
+kubectl apply -k github.com/rancher/system-upgrade-controller
+```
+
+To enable the automatic upgrades:
+
+``` bash
+kubectl apply -f - <<EOF
+# Server plan
+apiVersion: upgrade.cattle.io/v1
+kind: Plan
+metadata:
+  name: master-plan
+  namespace: system-upgrade
+spec:
+  concurrency: 1
+  cordon: true
+  nodeSelector:
+    matchExpressions:
+    - key: node-role.kubernetes.io/control-plane
+      operator: In
+      values:
+      - "true"
+  serviceAccountName: system-upgrade
+  upgrade:
+    image: rancher/k3s-upgrade
+  channel: https://update.k3s.io/v1-release/channels/stable
+---
+# Agent plan
+apiVersion: upgrade.cattle.io/v1
+kind: Plan
+metadata:
+  name: agent-plan
+  namespace: system-upgrade
+spec:
+  concurrency: 1
+  cordon: true
+  nodeSelector:
+    matchExpressions:
+    - key: node-role.kubernetes.io/control-plane
+      operator: DoesNotExist
+  prepare:
+    args:
+    - prepare
+    - master-plan
+    image: rancher/k3s-upgrade
+  serviceAccountName: system-upgrade
+  upgrade:
+    image: rancher/k3s-upgrade
+  channel: https://update.k3s.io/v1-release/channels/stable
+EOF
+```
+

--- a/resources/k3s-system-upgrade/install.sh
+++ b/resources/k3s-system-upgrade/install.sh
@@ -1,0 +1,19 @@
+#!/bin/env bash
+
+##
+## Copyright Jonathan Battiato
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+kubectl apply -f "https://github.com/rancher/system-upgrade-controller/releases/latest/download/system-upgrade-controller.yaml"

--- a/resources/k3s-system-upgrade/plans.yaml
+++ b/resources/k3s-system-upgrade/plans.yaml
@@ -1,0 +1,44 @@
+# Server plan
+apiVersion: upgrade.cattle.io/v1
+kind: Plan
+metadata:
+  name: master-plan
+  namespace: system-upgrade
+spec:
+  concurrency: 1
+  cordon: true
+  nodeSelector:
+    matchExpressions:
+    - key: node-role.kubernetes.io/control-plane
+      operator: In
+      values:
+      - "true"
+  serviceAccountName: system-upgrade
+  upgrade:
+    image: rancher/k3s-upgrade
+  channel: https://update.k3s.io/v1-release/channels/stable
+  #version: v1.28.2+k3s1
+---
+# Agent plan
+apiVersion: upgrade.cattle.io/v1
+kind: Plan
+metadata:
+  name: agent-plan
+  namespace: system-upgrade
+spec:
+  concurrency: 1
+  cordon: true
+  nodeSelector:
+    matchExpressions:
+    - key: node-role.kubernetes.io/control-plane
+      operator: DoesNotExist
+  prepare:
+    args:
+    - prepare
+    - master-plan
+    image: rancher/k3s-upgrade
+  serviceAccountName: system-upgrade
+  upgrade:
+    image: rancher/k3s-upgrade
+  channel: https://update.k3s.io/v1-release/channels/stable
+  #version: v1.28.2+k3s1


### PR DESCRIPTION
This patch introduce the "Day 2 Operations" documentation
and configurations.

This includes:
* backups
* observability
* upgrades

For the moment only the upgrades of the k3s itself
is covered through the automatic upgrades:
https://docs.k3s.io/upgrades/automated