### PR TITLE
fix: overwrite longhorn auth file and calico replacement in sed

### DIFF
--- a/resources/longhorn/install.sh
+++ b/resources/longhorn/install.sh
@@ -36,7 +36,7 @@ chmod +x longhornctl
 kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/"${VERSION}"/deploy/longhorn.yaml
 
 # Create basic auth secret to access UI
-USER="admin" ; PASSWORD=$(pwgen 8 1) ; echo "${USER}:$(openssl passwd -stdin -apr1 <<< "${PASSWORD}")" >> resources/longhorn/auth
+USER="admin" ; PASSWORD=$(pwgen 8 1) ; echo "${USER}:$(openssl passwd -stdin -apr1 <<< "${PASSWORD}")" > resources/longhorn/auth
 echo "${PASSWORD}" > resources/longhorn/password
 echo ""
 echo "The password to access Longhorn UI is: ${PASSWORD}"
@@ -46,5 +46,4 @@ kubectl -n longhorn-system create secret generic basic-auth --from-file=resource
 
 # Deploy ingress to allow access UI
 kubectl -n longhorn-system apply -f resources/longhorn/longhorn-ingress.yaml
-
 

--- a/scripts/install-kluster.sh
+++ b/scripts/install-kluster.sh
@@ -350,7 +350,7 @@ main(){
 
         if grep "calico" "${RESOURCES_FILE}" >/dev/null 2>&1
         then
-            sed -i -e 's/#calico/^calico/' "${RESOURCES_FILE}"
+            sed -i -e 's/#calico/calico/' "${RESOURCES_FILE}"
         fi
     fi
 }


### PR DESCRIPTION
This patch fixes a few bugs in the following scripts:

- the `install.sh` script from longhorn resource: where the credentials were always appended to an existing "auth" file compromising new installations;
- the `install-kluster.sh` script: where the uncomment `sed` command was adding a `^` character before the calico resource name.

